### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/Auth/SAML2/Assertion.pm6
+++ b/lib/Auth/SAML2/Assertion.pm6
@@ -1,7 +1,7 @@
 use XML;
 use XML::Signature;
 
-class Auth::SAML2::Assertion;
+unit class Auth::SAML2::Assertion;
 
 has $.issuer;
 has $.subject;

--- a/lib/Auth/SAML2/Response.pm6
+++ b/lib/Auth/SAML2/Response.pm6
@@ -4,7 +4,7 @@ use UUID;
 
 use Auth::SAML2::Assertion;
 
-class Auth::SAML2::Response;
+unit class Auth::SAML2::Response;
 
 has $.issuer;
 has $.status;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.
